### PR TITLE
Fix coordinate system handling

### DIFF
--- a/PLC_PRG.st
+++ b/PLC_PRG.st
@@ -6,11 +6,13 @@
 //
 PROGRAM PLC_PRG
 VAR
-    // Visualization and motion tracking variables
-    VisuX_tmp : REAL := 0.0; // Internal X position
-    VisuY_tmp : REAL := 0.0; // Internal Y position
-    VisuPosX : INT := 0;     // Position used in visualization
-    VisuPosY : INT := 0;
+    // Visualization and TCP tracking variables
+    TCPPos : Pos2D := (X:=0.0, Y:=0.0); // TCP position in local coordinates
+    VisuPosX : INT := 0;                // Visualization X (upper left origin)
+    VisuPosY : INT := 0;                // Visualization Y (upper left origin)
+    StartOffset : Pos2D := (X:=0.0, Y:=0.0); // Offset of first path point
+    CircleWidth : REAL := 10.0;         // Visual element width for centring
+    InitDone : BOOL := FALSE;
 
     TargetX : REAL := 0.0;
     TargetY : REAL := 0.0;
@@ -33,30 +35,47 @@ VAR
     PathLength : INT := 2;
     MoveFB : FB_TrapezoidalMove;
     ArcFB : FB_CircularMove;
+    StartRel : Pos2D;
+    MidRel : Pos2D;
+    EndRel : Pos2D;
 END_VAR
+
+// Automatic reset on first cycle
+IF NOT InitDone THEN
+    Reset := TRUE;
+    InitDone := TRUE;
+END_IF;
 
 // Reset position and speed values
 IF Reset THEN
-	
-	VisuPosX := 0; // Reset visualization X position
-    VisuPosY := 0; // Reset visualization Y position
-	
-	VisuX_tmp := 0.0; // Reset precise X position
-    VisuY_tmp := 0.0; // Reset precise Y position
-	
-	v := 0; // Reset velocity
-	
+    StartOffset.X := Path[1].P1.X;
+    StartOffset.Y := Path[1].P1.Y;
+
+    TCPPos.X := 0.0;
+    TCPPos.Y := 0.0;
+
+    VisuPosX := TO_INT(TCPPos.X - CircleWidth / 2.0);
+    VisuPosY := TO_INT(TCPPos.Y - CircleWidth / 2.0);
+
+    v := 0; // Reset velocity
+    Reset := FALSE;
 END_IF
 
 // Control movement execution
 IF MotionActive AND CurrentIndex <= PathLength THEN
     t := t + cycle_time;
 
+    StartRel.X := Path[CurrentIndex].P1.X - StartOffset.X;
+    StartRel.Y := Path[CurrentIndex].P1.Y - StartOffset.Y;
+
     IF NOT Path[CurrentIndex].IsArc THEN
+        EndRel.X := Path[CurrentIndex].P2.X - StartOffset.X;
+        EndRel.Y := Path[CurrentIndex].P2.Y - StartOffset.Y;
+
         // Handle linear motion segments
         MoveFB(
-            StartPos := Path[CurrentIndex].P1,
-            TargetPos := Path[CurrentIndex].P2,
+            StartPos := StartRel,
+            TargetPos := EndRel,
             MaxSpeed := MaxSpeed,
             Accel := Accel,
             t := t,
@@ -64,14 +83,21 @@ IF MotionActive AND CurrentIndex <= PathLength THEN
         );
 
         // Integrate velocity to update position
-        VisuX_tmp := VisuX_tmp + MoveFB.SpeedX * cycle_time;
-        VisuY_tmp := VisuY_tmp + MoveFB.SpeedY * cycle_time;
+        TCPPos.X := TCPPos.X + MoveFB.SpeedX * cycle_time;
+        TCPPos.Y := TCPPos.Y + MoveFB.SpeedY * cycle_time;
+        TargetX := EndRel.X;
+        TargetY := EndRel.Y;
     ELSE
+        MidRel.X := Path[CurrentIndex].P2.X - StartOffset.X;
+        MidRel.Y := Path[CurrentIndex].P2.Y - StartOffset.Y;
+        EndRel.X := Path[CurrentIndex].P3.X - StartOffset.X;
+        EndRel.Y := Path[CurrentIndex].P3.Y - StartOffset.Y;
+
         // Handle arc-based motion segments
         ArcFB(
-            P1 := Path[CurrentIndex].P1,
-            P2 := Path[CurrentIndex].P2,
-            P3 := Path[CurrentIndex].P3,
+            P1 := StartRel,
+            P2 := MidRel,
+            P3 := EndRel,
             MaxSpeed := MaxSpeed,
             Accel := Accel,
             t := t,
@@ -79,20 +105,18 @@ IF MotionActive AND CurrentIndex <= PathLength THEN
         );
 
         // Integrate velocity to update position
-        VisuX_tmp := VisuX_tmp + ArcFB.SpeedX * cycle_time;
-        VisuY_tmp := VisuY_tmp + ArcFB.SpeedY * cycle_time;
+        TCPPos.X := TCPPos.X + ArcFB.SpeedX * cycle_time;
+        TCPPos.Y := TCPPos.Y + ArcFB.SpeedY * cycle_time;
+        TargetX := EndRel.X;
+        TargetY := EndRel.Y;
     END_IF;
 
     // Convert precise position to integer for visualization
-    VisuPosX := TO_INT(VisuX_tmp);
-    VisuPosY := TO_INT(VisuY_tmp);
-
-    // Set destination for current segment
-    TargetX := Path[CurrentIndex].P3.X;
-    TargetY := Path[CurrentIndex].P3.Y;
+    VisuPosX := TO_INT(TCPPos.X - CircleWidth / 2.0);
+    VisuPosY := TO_INT(TCPPos.Y - CircleWidth / 2.0);
 
     // Check if current target is reached and progress to next segment
-    IF ABS(VisuX_tmp - TargetX) < 0.5 AND ABS(VisuY_tmp - TargetY) < 0.5 THEN
+    IF ABS(TCPPos.X - TargetX) < 0.5 AND ABS(TCPPos.Y - TargetY) < 0.5 THEN
         t := 0.0;
         CurrentIndex := CurrentIndex + 1;
 


### PR DESCRIPTION
## Summary
- adjust PLC logic to track TCP position separately from visualization
- translate movement instructions to coordinates relative to the first path point
- offset the visualisation on reset using the circle width

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685e5636aa2c832787934b9884124311