### PR TITLE
Refine motion interface

### DIFF
--- a/FB_CircularMove.st
+++ b/FB_CircularMove.st
@@ -35,11 +35,11 @@ VAR
     s_t : REAL;
     v : REAL;
     Angle : REAL;
-	angleP2 : REAL;
+    angleP2 : REAL;
     AngularSpeed : REAL;
     t_dec : REAL;
 
-    (* Variables for circle center calculation using perpendicular bisectors *)
+    // Variables for circle center calculation using perpendicular bisectors
     dx12, dy12, dx23, dy23 : REAL;
     M12X, M12Y, M23X, M23Y : REAL;
     RHS1, RHS2, D : REAL;

--- a/FB_TrapezoidalMove.st
+++ b/FB_TrapezoidalMove.st
@@ -17,7 +17,7 @@ VAR_INPUT
     MaxSpeed : REAL;    // Maximum speed during movement
     Accel : REAL;       // Acceleration used for ramp-up and ramp-down
     t : REAL;           // Elapsed time since start of movement
-    DecelerateAtEnd : BOOL;
+    DecelerateAtEnd : BOOL; // Whether to ramp down at the end
 END_VAR
 VAR_OUTPUT
     SpeedX : REAL;      // Current speed in the X direction
@@ -61,7 +61,7 @@ ELSE
     // Determine current speed magnitude
     IF t < t_acc THEN
         v := Accel * t;
-    ELSIF t < t_acc + t_const THEN
+    ELSIF t < t_acc + t_const OR NOT DecelerateAtEnd THEN
         v := MaxSpeed;
     ELSIF t < t_total THEN
         v := MaxSpeed - Accel * (t - t_acc - t_const);

--- a/PLC_PRG.st
+++ b/PLC_PRG.st
@@ -33,8 +33,8 @@ VAR
     Reset : BOOL := FALSE;
 
     Path : ARRAY[1..2] OF PathPoint := [
-        (P1:=(X:=25.0, Y:=150.0), P2:=(X:=125.0, Y:=150.0), P3:=(X:=125.0, Y:=150.0), IsArc:=FALSE, End:=FALSE),
-        (P1:=(X:=125.0, Y:=150.0), P2:=(X:=250.0, Y:=250.0), P3:=(X:=125.0, Y:=350.0), IsArc:=TRUE, End:=TRUE)
+        (P1:=(X:=25.0, Y:=150.0), P2:=(X:=125.0, Y:=150.0), P3:=(X:=125.0, Y:=150.0), IsArc:=FALSE, Break:=FALSE),
+        (P1:=(X:=125.0, Y:=150.0), P2:=(X:=250.0, Y:=250.0), P3:=(X:=125.0, Y:=350.0), IsArc:=TRUE, Break:=TRUE)
     ];
     CurrentIndex : INT := 1;
     PathLength : INT := 2;
@@ -78,7 +78,7 @@ IF MotionActive AND CurrentIndex <= PathLength THEN
             MaxSpeed := MaxSpeed,
             Accel := Accel,
             t := t,
-            DecelerateAtEnd := Path[CurrentIndex].End
+            DecelerateAtEnd := Path[CurrentIndex].Break
         );
 
         // Integrate velocity to update position
@@ -94,7 +94,7 @@ IF MotionActive AND CurrentIndex <= PathLength THEN
             MaxSpeed := MaxSpeed,
             Accel := Accel,
             t := t,
-            DecelerateAtEnd := Path[CurrentIndex].End
+            DecelerateAtEnd := Path[CurrentIndex].Break
         );
 
         // Integrate velocity to update position
@@ -115,10 +115,6 @@ IF MotionActive AND CurrentIndex <= PathLength THEN
     IF ABS(TCPAbs.X - Target.X) < 0.5 AND ABS(TCPAbs.Y - Target.Y) < 0.5 THEN
         t := 0.0;
         CurrentIndex := CurrentIndex + 1;
-
-        IF Path[CurrentIndex - 1].End THEN
-            MotionActive := FALSE;
-        END_IF;
     END_IF;
 END_IF;
 

--- a/PathPoint.st
+++ b/PathPoint.st
@@ -10,6 +10,6 @@ STRUCT
     P2 : POS2D; // Midpoint for arc or endpoint for line
     P3 : POS2D; // Endpoint for arc (ignored for line)
     IsArc : BOOL;
-    End : BOOL;
+    Break : BOOL; // If TRUE, stop after this segment
 END_STRUCT
 END_TYPE


### PR DESCRIPTION
## Summary
- add `DecelerateAtEnd` input back to `FB_TrapezoidalMove`
- skip ramp-down when it is false
- rename `End` field in `PathPoint` to `Break`
- update calls in `PLC_PRG`
- stop resetting `MotionActive` when hitting a break

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e801a0bec8327beaf0ed42ebb5cdf