### PR TITLE
Allow initializing speeds

### DIFF
--- a/FB_CircularMove.st
+++ b/FB_CircularMove.st
@@ -14,9 +14,9 @@ VAR_INPUT
     t : REAL;               // Time since start of movement [s]
     DecelerateAtEnd : BOOL; // Whether to decelerate at the end of movement
 END_VAR
-VAR_OUTPUT
-    SpeedX : REAL;          // Current velocity in X direction
-    SpeedY : REAL;          // Current velocity in Y direction
+VAR_IN_OUT
+    SpeedX : REAL;          // Current velocity in X direction (initial value on first call)
+    SpeedY : REAL;          // Current velocity in Y direction (initial value on first call)
 END_VAR
 VAR
     CenterX, CenterY : REAL;
@@ -34,6 +34,7 @@ VAR
     t_total : REAL;
     s_t : REAL;
     v : REAL;
+    v0 : REAL;
     Angle : REAL;
 	angleP2 : REAL;
     AngularSpeed : REAL;
@@ -93,10 +94,13 @@ END_IF;
 
 // Set direction multiplier: -1 for clockwise, +1 for counterclockwise
 IF CW = TRUE THEN
-	Dir := -1.0;
+        Dir := -1.0;
 ELSE
-	Dir := 1.0;
+        Dir := 1.0;
 END_IF
+
+    // Magnitude of initial velocity provided via SpeedX/SpeedY
+    v0 := SQRT(SpeedX * SpeedX + SpeedY * SpeedY);
 
 // Adjust DeltaAngle for proper arc direction considering CW/CCW
 DeltaAngle := EndAngle - StartAngle;
@@ -107,23 +111,30 @@ ELSIF DeltaAngle > 0 AND CW THEN
 END_IF;
 DeltaAngle := ABS(DeltaAngle);
 ArcLength := Radius * DeltaAngle;
-t_acc := MaxSpeed / Accel;
-s_acc := 0.5 * Accel * t_acc * t_acc;
-s_const := ArcLength - 2 * s_acc;
+t_acc := (MaxSpeed - v0) / Accel;
+IF t_acc < 0 THEN
+    t_acc := 0.0;
+END_IF;
+s_acc := v0 * t_acc + 0.5 * Accel * t_acc * t_acc;
+t_dec := MaxSpeed / Accel;
+s_const := ArcLength - s_acc - (0.5 * MaxSpeed * t_dec);
 
 IF s_const < 0 THEN
-    t_acc := SQRT(ArcLength / Accel);
+    // Triangular profile starting from v0
+    v := SQRT(v0 * v0 + 2 * Accel * ArcLength);
+    t_acc := (v - v0) / Accel;
+    t_dec := v / Accel;
     t_const := 0.0;
-    t_total := 2 * t_acc;
+    t_total := t_acc + t_dec;
 ELSE
     t_const := s_const / MaxSpeed;
-    t_total := 2 * t_acc + t_const;
+    t_total := t_acc + t_const + t_dec;
 END_IF;
 
 // Acceleration phase
 IF t < t_acc THEN
-    v := Accel * t;
-    s_t := 0.5 * Accel * t * t;
+    v := v0 + Accel * t;
+    s_t := v0 * t + 0.5 * Accel * t * t;
 
 // Constant speed phase or skipping deceleration
 ELSIF t < t_acc + t_const OR NOT DecelerateAtEnd THEN

--- a/FB_TrapezoidalMove.st
+++ b/FB_TrapezoidalMove.st
@@ -19,9 +19,9 @@ VAR_INPUT
     t : REAL;           // Elapsed time since start of movement
     DecelerateAtEnd : BOOL;
 END_VAR
-VAR_OUTPUT
-    SpeedX : REAL;      // Current speed in the X direction
-    SpeedY : REAL;      // Current speed in the Y direction
+VAR_IN_OUT
+    SpeedX : REAL;      // Current speed in the X direction (initial value on first call)
+    SpeedY : REAL;      // Current speed in the Y direction (initial value on first call)
 END_VAR
 VAR
     TotalDist : REAL;   // Total distance between start and target
@@ -33,6 +33,8 @@ VAR
     t_const : REAL;     // Time spent at constant MaxSpeed
     t_total : REAL;     // Total duration of the entire move
     v : REAL;           // Current magnitude of the velocity vector
+    v0 : REAL;          // Initial velocity magnitude
+    t_dec : REAL;       // Time needed to decelerate to 0
 END_VAR
 
 // Compute direction and total distance
@@ -44,23 +46,33 @@ ELSE
     DirX := (TargetPos.X - StartPos.X) / TotalDist;
     DirY := (TargetPos.Y - StartPos.Y) / TotalDist;
 
-    t_acc := MaxSpeed / Accel;
-    s_acc := 0.5 * Accel * t_acc * t_acc;
-    s_const := TotalDist - 2 * s_acc;
+    // Determine initial speed magnitude from provided inputs
+    v0 := SQRT(SpeedX * SpeedX + SpeedY * SpeedY);
+
+    t_acc := (MaxSpeed - v0) / Accel;
+    IF t_acc < 0 THEN
+        t_acc := 0;
+    END_IF;
+    s_acc := v0 * t_acc + 0.5 * Accel * t_acc * t_acc;
+    t_dec := MaxSpeed / Accel;
+    s_const := TotalDist - s_acc - (0.5 * MaxSpeed * t_dec);
+
     IF s_const < 0 THEN
-        // Triangular profile
-        t_acc := SQRT(TotalDist / Accel);
+        // Triangular profile starting from v0
+        v := SQRT(v0 * v0 + 2 * Accel * TotalDist);
+        t_acc := (v - v0) / Accel;
+        t_dec := v / Accel;
         t_const := 0;
-        t_total := 2 * t_acc;
+        t_total := t_acc + t_dec;
     ELSE
         // Trapezoidal profile
         t_const := s_const / MaxSpeed;
-        t_total := 2 * t_acc + t_const;
+        t_total := t_acc + t_const + t_dec;
     END_IF;
 
     // Determine current speed magnitude
     IF t < t_acc THEN
-        v := Accel * t;
+        v := v0 + Accel * t;
     ELSIF t < t_acc + t_const THEN
         v := MaxSpeed;
     ELSIF t < t_total THEN

--- a/PLC_PRG.st
+++ b/PLC_PRG.st
@@ -29,6 +29,10 @@ VAR
     MaxSpeed : REAL := 50.0;
     Accel : REAL := 10.0;
 
+    // Current velocity components used by the motion function blocks
+    CurSpeedX : REAL := 0.0;
+    CurSpeedY : REAL := 0.0;
+
     MotionActive : BOOL := TRUE;
     Reset : BOOL := FALSE;
 
@@ -64,6 +68,10 @@ IF Reset THEN
     VisuPosX := TO_INT(TCPRel.X - CircleWidth / 2.0);
     VisuPosY := TO_INT(TCPRel.Y - CircleWidth / 2.0);
 
+    // Reset velocity
+    CurSpeedX := 0.0;
+    CurSpeedY := 0.0;
+
     Reset := FALSE;
 END_IF
 
@@ -79,12 +87,14 @@ IF MotionActive AND CurrentIndex <= PathLength THEN
             MaxSpeed := MaxSpeed,
             Accel := Accel,
             t := t,
-            DecelerateAtEnd := Path[CurrentIndex].End
+            DecelerateAtEnd := Path[CurrentIndex].End,
+            SpeedX := CurSpeedX,
+            SpeedY := CurSpeedY
         );
 
         // Integrate velocity to update position
-        TCPAbs.X := TCPAbs.X + MoveFB.SpeedX * cycle_time;
-        TCPAbs.Y := TCPAbs.Y + MoveFB.SpeedY * cycle_time;
+        TCPAbs.X := TCPAbs.X + CurSpeedX * cycle_time;
+        TCPAbs.Y := TCPAbs.Y + CurSpeedY * cycle_time;
         Target := Path[CurrentIndex].P2;
     ELSE
         // Handle arc-based motion segments
@@ -95,12 +105,14 @@ IF MotionActive AND CurrentIndex <= PathLength THEN
             MaxSpeed := MaxSpeed,
             Accel := Accel,
             t := t,
-            DecelerateAtEnd := Path[CurrentIndex].End
+            DecelerateAtEnd := Path[CurrentIndex].End,
+            SpeedX := CurSpeedX,
+            SpeedY := CurSpeedY
         );
 
         // Integrate velocity to update position
-        TCPAbs.X := TCPAbs.X + ArcFB.SpeedX * cycle_time;
-        TCPAbs.Y := TCPAbs.Y + ArcFB.SpeedY * cycle_time;
+        TCPAbs.X := TCPAbs.X + CurSpeedX * cycle_time;
+        TCPAbs.Y := TCPAbs.Y + CurSpeedY * cycle_time;
         Target := Path[CurrentIndex].P3;
     END_IF;
 

--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ trapezoidal and circular motion profiles.
 The project can be imported into a ctrlX PLC Engineering workspace.  It
 is mainly intended as a learning resource, so the motion logic is kept
 minimal and easy to read.
+
+## Accessing and Initialising Speed
+
+`FB_TrapezoidalMove` and `FB_CircularMove` allow their `SpeedX` and
+`SpeedY` values to be passed in as `VAR_IN_OUT` parameters.  These inputs
+provide the initial velocity of a new motion segment and are updated on
+every call.  You can reset these variables to zero when restarting the
+simulation or feed them from the previous segment to achieve continuous
+motion.


### PR DESCRIPTION
## Summary
- expose `SpeedX` and `SpeedY` as `VAR_IN_OUT`
- add optional initial speed logic in move function blocks
- track current speed in `PLC_PRG`
- document how to initialise movement speed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68668110165083278b92ebc181a62691