### PR TITLE
Add canvas offset function block

### DIFF
--- a/FB_CanvasOffset.st
+++ b/FB_CanvasOffset.st
@@ -1,0 +1,18 @@
+//
+// Function block to translate coordinates from a source reference
+// frame (e.g. visualisation) to a local canvas coordinate system.
+// The output is simply the input position shifted by the provided
+// offset.
+//
+FUNCTION_BLOCK FB_CanvasOffset
+VAR_INPUT
+    Source : Pos2D;      // Position in source coordinate system
+    Offset : Pos2D;      // Offset of the canvas origin in source coordinates
+END_VAR
+VAR_OUTPUT
+    Canvas : Pos2D;      // Transformed position relative to canvas origin
+END_VAR
+
+Canvas.X := Source.X - Offset.X;
+Canvas.Y := Source.Y - Offset.Y;
+// End of FB_CanvasOffset

--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ provide the initial velocity of a new motion segment and are updated on
 every call.  You can reset these variables to zero when restarting the
 simulation or feed them from the previous segment to achieve continuous
 motion.
+
+## Canvas Coordinate Translation
+
+`FB_CanvasOffset` shifts a position from the visualisation coordinate frame
+into a local canvas coordinate system.  Pass the input position from the
+visu and the offset of your canvas origin to obtain the translated
+coordinates.


### PR DESCRIPTION
## Summary
- add a function block `FB_CanvasOffset` that shifts coordinates from the visu frame to the canvas frame
- document the block in README

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_686fda0adb188327973cdff209a0b82c