### PR TITLE
Adjust main program for canvas coordinates

### DIFF
--- a/PLC_PRG.st
+++ b/PLC_PRG.st
@@ -7,7 +7,7 @@ VAR
     // Integer coordinates for the visualization
     VisuPosX : INT := 0;                // X position in pixels
     VisuPosY : INT := 0;                // Y position in pixels
-    // Absolute position of the first path point
+    // Absolute offset of the canvas origin
     StartOffset : Pos2D := (X:=0.0, Y:=0.0);
     // Diameter of the circle used to draw the TCP
     CircleWidth : REAL := 10.0;
@@ -38,6 +38,12 @@ VAR
     PathLength : INT := 3;
     MoveFB : FB_LinealMove;
     ArcFB : FB_CircularMove;
+    // Helper to translate coordinates into the canvas frame
+    CanvasTrans : FU_CanvasOffset;
+    // Offset used for translating the path
+    PathOffset : Pos2D := (X:=0.0, Y:=0.0);
+    // Temporary positions after translation
+    TransP1, TransP2, TransP3 : Pos2D;
 END_VAR
 
 // Automatic reset on first cycle
@@ -48,10 +54,13 @@ END_IF;
 
 // Reset position and initialise offsets
 IF Reset THEN
-    // Record the absolute starting position
-    StartOffset := Path[1].P1;
+    // Offset of the path relative to the canvas
+    PathOffset := Path[1].P1;
 
-    // TCP starts at the first path point in absolute coordinates
+    // Start at the canvas origin (0,0)
+    StartOffset := (X:=0.0, Y:=0.0);
+
+    // TCP begins at the origin in absolute coordinates
     TCPAbs := StartOffset;
     // No displacement in the local frame at reset
     TCPRel.X := 0.0;
@@ -76,9 +85,15 @@ IF MotionActive AND CurrentIndex <= PathLength THEN
 
     IF NOT Path[CurrentIndex].IsArc THEN
         // Handle linear motion segments
+        // Translate path coordinates to the canvas frame
+        CanvasTrans(Source := Path[CurrentIndex].P1, Offset := PathOffset);
+        TransP1 := CanvasTrans.Canvas;
+        CanvasTrans(Source := Path[CurrentIndex].P2, Offset := PathOffset);
+        TransP2 := CanvasTrans.Canvas;
+
         MoveFB(
-            StartPos := Path[CurrentIndex].P1,
-            TargetPos := Path[CurrentIndex].P2,
+            StartPos := TransP1,
+            TargetPos := TransP2,
             MaxSpeed := MaxSpeed,
             Accel := Accel,
             t := t,
@@ -90,17 +105,25 @@ IF MotionActive AND CurrentIndex <= PathLength THEN
         // Integrate velocity to update position
         TCPAbs.X := TCPAbs.X + CurSpeedX * cycle_time;
         TCPAbs.Y := TCPAbs.Y + CurSpeedY * cycle_time;
-        Target := Path[CurrentIndex].P2;
+        Target := TransP2;
     ELSE
         // Handle arc-based motion segments
+        // Translate arc points to the canvas frame
+        CanvasTrans(Source := Path[CurrentIndex].P1, Offset := PathOffset);
+        TransP1 := CanvasTrans.Canvas;
+        CanvasTrans(Source := Path[CurrentIndex].P2, Offset := PathOffset);
+        TransP2 := CanvasTrans.Canvas;
+        CanvasTrans(Source := Path[CurrentIndex].P3, Offset := PathOffset);
+        TransP3 := CanvasTrans.Canvas;
+
         ArcFB(
-            P1 := Path[CurrentIndex].P1,
-            P2 := Path[CurrentIndex].P2,
-            P3 := Path[CurrentIndex].P3,
+            P1 := TransP1,
+            P2 := TransP2,
+            P3 := TransP3,
             MaxSpeed := MaxSpeed,
             Accel := Accel,
             t := t,
-            DecelerateAtEnd := Path[CurrentIndex].Break
+            DecelerateAtEnd := Path[CurrentIndex].Break,
             SpeedX := CurSpeedX,
             SpeedY := CurSpeedY
         );
@@ -108,7 +131,7 @@ IF MotionActive AND CurrentIndex <= PathLength THEN
         // Integrate velocity to update position
         TCPAbs.X := TCPAbs.X + CurSpeedX * cycle_time;
         TCPAbs.Y := TCPAbs.Y + CurSpeedY * cycle_time;
-        Target := Path[CurrentIndex].P3;
+        Target := TransP3;
     END_IF;
 
     // Update local coordinate from absolute position


### PR DESCRIPTION
## Summary
- compute canvas offset at reset and start at origin
- translate every path point to canvas coordinates before motion

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fe8ee13e08327b7e3c0eb153b06dc