### PR TITLE
Update TCPRel calculation after integration

### DIFF
--- a/PLC_PRG.st
+++ b/PLC_PRG.st
@@ -127,6 +127,9 @@ IF MotionActive THEN
             // Integrate velocity to update position
             TCPAbs.X := TCPAbs.X + CurSpeedX * cycle_time;
             TCPAbs.Y := TCPAbs.Y + CurSpeedY * cycle_time;
+            // Update relative coordinates after integrating
+            TCPRel.X := TCPAbs.X - StartOffset.X;
+            TCPRel.Y := TCPAbs.Y - StartOffset.Y;
             Target := Path[CurrentIndex].P2;
         ELSE
             // Handle arc-based motion segments
@@ -160,6 +163,9 @@ IF MotionActive THEN
     // Integrate velocity to update position
     TCPAbs.X := TCPAbs.X + CurSpeedX * cycle_time;
     TCPAbs.Y := TCPAbs.Y + CurSpeedY * cycle_time;
+    // Update relative coordinates after integrating
+    TCPRel.X := TCPAbs.X - StartOffset.X;
+    TCPRel.Y := TCPAbs.Y - StartOffset.Y;
 
     // Convert precise position to integer for visualization
     VisuPosX := TO_INT(TCPRel.X - CircleWidth / 2.0);


### PR DESCRIPTION
## Summary
- update `TCPRel` after each position integration step so the visualisation and return-home logic are in sync with the latest absolute coordinates

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6870e16510d08327b3b399ff162ea06d